### PR TITLE
Annihilation of differences in Belt

### DIFF
--- a/cascada/primitives/belt.py
+++ b/cascada/primitives/belt.py
@@ -10,8 +10,6 @@ See also:
 resulting in 56 small rounds.
 """
 
-import enum
-
 from cascada.bitvector.core import Constant
 from cascada.bitvector.operation import RotateLeft, RotateRight, Extract, Concat
 from cascada.bitvector.secondaryop import LutOperation
@@ -20,8 +18,6 @@ from cascada.bitvector.ssa import RoundBasedFunction
 from cascada.primitives.blockcipher import Encryption, Cipher
 from cascada.differential.opmodel import get_weak_model as get_differential_weak_model
 from cascada.linear.opmodel import get_weak_model as get_linear_weak_model
-
-from pprint import pprint
 
 class BeltKeySchedule(RoundBasedFunction):
     """Key schedule for Belt."""
@@ -112,9 +108,9 @@ class BeltEncryption(Encryption, RoundBasedFunction):
             if i == cls.num_rounds:
                 break
             # step 4
-            e = BeltG(b + c + K[i], 21) ^ Constant(i // 7 + 1, 32)
-            b = b + e
-            c = c - e
+            c = c + b
+            b = b + (BeltG(c + K[i], 21) ^ Constant(i // 7 + 1, 32))
+            c = c - b
             cls.add_round_outputs(a, b, c, d)
             i += 1
             if i == cls.num_rounds:


### PR DESCRIPTION
The following program
```python
from cascada.differential.difference import XorDiff
from cascada.smt.chsearch import ChModelAssertType, PrintingMode, round_based_ch_search
from cascada.primitives import belt

Belt = belt.BeltCipher

assert_type = ChModelAssertType.ValidityAndWeight

iterator = round_based_ch_search(Belt, 16, 24, XorDiff, assert_type, "btor",
    extra_chfinder_args={"exclude_zero_input_prop": True, "printing_mode": PrintingMode.Silent},
    extra_findnextchweight_args={"initial_weight": 0})

for (num_rounds, ch) in iterator:
    print(num_rounds, ":", ch.srepr())
```
run with the current version (https://github.com/ranea/CASCADA/commit/0fc1e2a5d84348c38b9984336e71d26f8338250d) of CASCADA gives the following result 
```
16 : Ch(w=14, id=00004000 00002000 00080000 80000000, od=00040000 90000000 80100000 80000000)
17 : Ch(w=15, id=80000000 00100001 00f00000 00000000, od=00000000 00000000 00000000 00000000)
18 : Ch(w=15, id=80000000 e0100000 00f00000 00000000, od=00000000 00000000 00000000 00000000)
19 : Ch(w=15, id=80000000 0010000b 00f00000 00000000, od=00000000 00000000 00000000 00000000)
20 : Ch(w=15, id=80000000 80100000 00f00000 00000000, od=00000000 00000000 00000000 00000000)
...
```
Tracing a nonzero input difference (`id`) for >= 17 rounds, CASCADA comes across zero output differences (`od`) that contradicts bijectivity of Belt.

The problem is solved by rewriting the central part of the Belt round. If we replace
```
# step 4
e = BeltG(b + c + K[i], 21) ^ Constant(i // 7 + 1, 32)
b = b + e
c = c - e
```
with
```
# step 4
c = c + b
b = b + (BeltG(c + K[i], 21) ^ Constant(i // 7 + 1, 32))
c = c - b
```
the output differences stop to annihilate:
```
16 : Ch(w=14, id=00001000 80020000 80000010 00000400, od=00000000 80000000 00100000 80000000)
17 : Ch(w=16, id=00001000 80010000 82000000 00000080, od=00000400 80000000 00100000 80000000)
18 : Ch(w=22, id=00001000 80008000 00000010 00000200, od=00000040 00004000 80000000 80000000)
19 : Ch(w=23, id=00020000 04000000 08010000 80000040, od=80000000 00000000 00000000 00000000)
20 : Ch(w=24, id=00080000 02000000 00900000 80000080, od=80000000 00100000 00000000 00000000)
21 : Ch(w=24, id=00080000 1fa00000 1fffc000 80000080, od=00040000 00000000 80000000 00000000)
22 : Ch(w=26, id=00020000 02000000 08040000 80000040, od=00008000 00100000 80000000 00000000)
23 : Ch(w=26, id=00020000 1fe00000 1defe000 80000040, od=00004000 00008000 80000000 00000000)
24 : Ch(w=29, id=00010000 08000000 00480000 80000020, od=80004000 00080000 80000000 00000000)
```

I guess that CASCADA's internal representation of the 3-line program 
```
e = BeltG(b + c + K[i], 21) ^ Constant(i // 7 + 1, 32)
b = b + e
c = c - e
```
does not guarantee bijectivity with respect to `(b, c)`. On the other hand, each line of the proposed equivalent program 
```
c = c + b
b = b + (BeltG(c + K[i], 21) ^ Constant(i // 7 + 1, 32))
c = c - b
```
provides bijectivity guarantees.
